### PR TITLE
Updating title variable reference

### DIFF
--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -3,7 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-	<title>{{meta_title}}</title>
+	<title>{{@meta.title}}</title>
 	<meta name="description" content="{{meta_description}}" />
     <link rel="shortcut icon" href="{{url @settings.favicon}}">
 	<meta name="HandheldFriendly" content="True" />


### PR DESCRIPTION
Title tag was incorrectly referencing `{{meta_title}}`. Updated to reference `{{@meta.title}}`.
